### PR TITLE
only try to use XDomainRequest for POST & GET

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -264,7 +264,7 @@
       var legacyCors = false;
       if (support.XDomainRequest) {
         var origin = location.protocol + '//' + location.host;
-        legacyCors = (/^\/\//.test(self.url) ? location.protocol + self.url : self.url).substring(0, origin.length) !== origin;
+        legacyCors = (/^\/\//.test(self.url) ? location.protocol + self.url : self.url).substring(0, origin.length) !== origin && && (self.method === 'GET' || self.method === 'POST');
       }
       var xhr = legacyCors ? new XDomainRequest() : new XMLHttpRequest()
 


### PR DESCRIPTION
I'd actually prefer if XDomainRequest was removed entirely as there are too many caveats http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx and I'm working on a more general iframe + post message solution for ie9 https://github.com/Financial-Times/ft-xdr
