### PR TITLE
Fix IE9 cors requests

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -328,7 +328,15 @@
         })
       })
 
-      xhr.send(typeof self._bodyInit === 'undefined' ? null : self._bodyInit)
+      var send = xhr.send.bind(xhr, typeof self._bodyInit === 'undefined' ? null : self._bodyInit)
+      if (legacyCors) {
+        xhr.onprogress = xhr.onprogress || function () {}
+        setTimeout(function () {
+          send()
+        })
+      } else {
+        send()
+      }
     })
   }
 


### PR DESCRIPTION
Needs `onprogress` (https://social.msdn.microsoft.com/Forums/ie/en-US/30ef3add-767c-4436-b8a9-f1ca19b4812e/ie9-rtm-xdomainrequest-issued-requests-may-abort-if-all-event-handlers-not-specified?forum=iewebdevelopment) handler and `setTimeout` (https://developer.mozilla.org/en-US/docs/Web/API/XDomainRequest#Example)
