### PR TITLE
Adding empty ontimeout

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -331,6 +331,7 @@
       var send = xhr.send.bind(xhr, typeof self._bodyInit === 'undefined' ? null : self._bodyInit)
       if (legacyCors) {
         xhr.onprogress = xhr.onprogress || function () {}
+        xhr.ontimeout = xhr.ontimeout || function () {}
         setTimeout(function () {
           send()
         })


### PR DESCRIPTION
Might help on some of those IE9 network errors - http://cypressnorth.com/programming/internet-explorer-aborting-ajax-requests-fixed/
